### PR TITLE
Serve .svg files with correct Content-Type header

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,6 +277,7 @@ async function webpackPlugin (fastify, opts) {
     if (filename.endsWith('.ico')) contentType = 'image/x-icon'
     if (filename.endsWith('.txt')) contentType = 'text/plain'
     if (filename.endsWith('.css')) contentType = 'text/css'
+    if (filename.endsWith('.svg')) contentType = 'image/svg+xml'
 
     const filepath = path.join(distDir, filename)
     return function (req, rep) {


### PR DESCRIPTION
SVG images must be served with the correct Content-Type header. Otherwise, browsers may misinterpret them.